### PR TITLE
fix: allow Windows builds by gating Unix-only Host variant

### DIFF
--- a/src/validation/postgres.rs
+++ b/src/validation/postgres.rs
@@ -51,6 +51,7 @@ pub async fn validate_postgres(postgres_url: &str) -> Result<(bool, Vec<String>)
 
 fn has_any_local_host(cfg: &Config) -> bool {
     cfg.get_hosts().iter().any(|h| match h {
+        #[cfg(unix)]
         Host::Unix(_) => true, // local unix socket
         Host::Tcp(s) => is_local_tcp_host(s),
     })


### PR DESCRIPTION
## Summary
- avoid referencing Unix socket host variant on non-Unix targets

## Testing
- `cargo check` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e05c8e8483268ce12dcac8c55705