### PR TITLE
Added an optional exclude_words list to PatternRequirements so matche…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Added `pattern_requirements` for rules. Enables post-regex character-class checks (digits, uppercase, lowercase, specials) to reduce false positives without lookarounds. Provides lightweight, in-memory validation after matches, keeping patterns fast and readable.
-- Added an optional `exclude_words` list to `PatternRequirements` so matches containing case-insensitive placeholder words are filtered out, with accompanying tests to cover the new behavior.
+- Added an optional `ignore_if_contains` list to `PatternRequirements` within the Rules structure, so matches containing case-insensitive placeholder words are filtered out, with accompanying tests to cover the new behavior.
 - Updated many rules with `pattern_requirements`
 - Automatically set `--no-dedup` whenever `--manage-baseline` is supplied so baseline management retains every occurrence of a finding
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,21 @@ However, you may want to add your own custom rules, or modify a detection to bet
 
 First, review [docs/RULES.md](/docs/RULES.md) to learn how to create custom Kingfisher rules.
 
+### Pattern requirements and placeholder filtering
+
+Every rule can declare optional `pattern_requirements` to enforce additional character checks after a regex matches. Each field
+is independent:
+
+- `min_digits`, `min_uppercase`, `min_lowercase`, and `min_special_chars` enforce complexity thresholds.
+- `special_chars` lets you override the set of characters counted as "special" when `min_special_chars` is used.
+- `ignore_if_contains` lists case-insensitive substrings that should cause a match to be discarded (for example, to drop
+  `test`, `demo`, or `localhost` values). Kingfisher still accepts the legacy `exclude_words` key as an alias when loading
+  existing rule files.
+
+When a match is skipped because of `ignore_if_contains`, Kingfisher logs the event at the `DEBUG` level alongside the rule that
+was evaluated. If you need to keep those matches for a particular scan, pass `--no-ignore-if-contains` to `kingfisher scan` to
+disable the substring filter without editing any rule files.
+
 Once you've done that, you can provide your custom rules (defined in a YAML file) and provide it to Kingfisher at runtime --- no recompiling required!
 
 # 🎉 Usage
@@ -1168,6 +1183,8 @@ leaves the default unchanged.
 - `--skip-aws-account-file <FILE>`: Load AWS account numbers to skip from a file (one account per line; `#` comments allowed)
 - `--ignore-comment <DIRECTIVE>`: Honor additional inline directives from other scanners (repeatable; e.g. `--ignore-comment "gitleaks:allow"`)
 - `--no-ignore`: Disable inline directives entirely so every match is reported
+- `--no-ignore-if-contains`: Ignore the `ignore_if_contains` filter in rules so placeholder words still produce findings
+
 ## Understanding `--confidence`
 
 The `--confidence` flag sets a minimum confidence threshold, not an exact match.

--- a/data/rules/aiven.yml
+++ b/data/rules/aiven.yml
@@ -9,7 +9,7 @@ rules:
       (
         [a-z0-9/+=]{372}      
       )
-      \b
+      (?:[^A-Za-z0-9/+=]|$)
     pattern_requirements:
       min_digits: 2
       min_uppercase: 1

--- a/data/rules/bitbucket.yml
+++ b/data/rules/bitbucket.yml
@@ -51,7 +51,7 @@ rules:
     confidence: medium
     examples:
       - bitbucket_key=HedmnK9h6KD_eh9KK8FlI9ahUc8WfaNZ4gulbrtN2ouV
-      - bitbucket_secret=kd8j2h4jf9s8mf6l4k9j2h4jf9s8mf6l4k9j2h4jf9s8mf6l
+      - bitbucket_secret=kd8j2h4jf9s8mf6l4k9j2h4jf9s8mf6l4k9j2h4jf9s8
     validation:
       type: Http
       content:

--- a/data/rules/confluent.yml
+++ b/data/rules/confluent.yml
@@ -32,12 +32,12 @@ rules:
       (
         [A-Z0-9\+/]{64}
       )
-      \b
+      (?:[^A-Za-z0-9/+=]|$)
     min_entropy: 3.3
     confidence: medium
     examples:
       - confluent secret=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ab
-      - kafka_token=ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCD
+      - kafka_token=ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzAB
     references:
       - https://docs.confluent.io/cloud/current/api.html#tag/API-Keys-(iamv2)/operation/getIamV2ApiKey
     validation:

--- a/data/rules/coze.yml
+++ b/data/rules/coze.yml
@@ -3,7 +3,6 @@ rules:
     id: kingfisher.coze.1
     pattern: |
       (?xi)
-      \b
       coze
       (?:.|[\n\r]){0,32}?
       \b
@@ -37,6 +36,6 @@ rules:
       - https://www.coze.com/docs/developer_guides/coze_api_overview
       - https://www.coze.com/docs/developer_guides/retrieve_files
     examples:
-      - "pat_DlOG7fNcVfmw8cYhPWNcdfwrjjzwDr9EkV8EBjzHdgRWU2DzqHC1pPe0x590NN5f"
-      - "pat_93QiTdIvZGuRCFcfGTQJJ1VIYZ9dNHanX88wKoMojwMk3tX5tKqfFtxUp0ux8CjI"
-      - "pat_WvUTLYq5yZyaqegkyLSxXJMjXAJotjYEuC1sqT8daFlfwM3BiaRVJIZsER42DnhV"
+      - "key_coze = pat_DlOG7fNcVfmw8cYhPWNcdfwrjjzwDr9EkV8EBjzHdgRWU2DzqHC1pPe0x590NN5f"
+      - "coze_token = pat_93QiTdIvZGuRCFcfGTQJJ1VIYZ9dNHanX88wKoMojwMk3tX5tKqfFtxUp0ux8CjI"
+      - "coze-key: pat_WvUTLYq5yZyaqegkyLSxXJMjXAJotjYEuC1sqT8daFlfwM3BiaRVJIZsER42DnhV"

--- a/data/rules/easypost.yml
+++ b/data/rules/easypost.yml
@@ -6,7 +6,7 @@ rules:
       \b
       (
         EZ[AT]K
-        [A-Z0-9]{54}
+        [A-Za-z0-9]{54}
       )
       \b
     pattern_requirements:

--- a/data/rules/generic.yml
+++ b/data/rules/generic.yml
@@ -10,7 +10,7 @@ rules:
       )
       \b
     pattern_requirements:
-      min_digits: 4
+      min_digits: 2
     min_entropy: 3.3
     confidence: low
     examples:

--- a/data/rules/intercom.yml
+++ b/data/rules/intercom.yml
@@ -18,7 +18,7 @@ rules:
 
     examples:
       - "intercom_access_token: dG9rOvI0NmJlMTA5XzQwM2NfNDVlM184MjQzXzkwMDnmOTE1NGIyONoxOjA="
-      - ic_token = "g1ZsclJXTjNfc1pBSzJDemE0eFVDU0U5c25CeDN4Vm9hQ2Zac0hXemZHNGVDPQ=="
+      - ic_token = "g1ZsclJXTjNfc1pBSzJDemE0eFVDU0U5c25CeDN4Vm9hQ2Zac0hXemZHNPQ=="
 
     references:
       - https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis

--- a/data/rules/mongodb.yml
+++ b/data/rules/mongodb.yml
@@ -82,7 +82,7 @@ rules:
       )
       \b
     pattern_requirements:
-      exclude_words:
+      ignore_if_contains:
         - "@localhost"
         - "@127.0.0.1"
     min_entropy: 3

--- a/data/rules/odbc.yml
+++ b/data/rules/odbc.yml
@@ -6,6 +6,10 @@ rules:
       (?: User | User\ Id | UserId | Uid) \s*=\s* ([^\s;]{3,100}) \s* ;
       [\ \t]* .{0,10} [\ \t]* 
       (?: Password | Pwd) \s*=\s* ([^\t\ ;]{3,100}) \s* (?: [;] | $)
+    pattern_requirements:
+      ignore_if_contains:
+        - "localhost"
+        - "127.0.0.1"
     min_entropy: 3.3
     confidence: medium
     examples:

--- a/data/rules/postgres.yml
+++ b/data/rules/postgres.yml
@@ -24,6 +24,10 @@ rules:
       (?:
         \d+
       )
+    pattern_requirements:
+      ignore_if_contains:
+        - "@localhost"
+        - "@127.0.0.1"
     min_entropy: 3.3
     confidence: medium
     examples:

--- a/data/rules/recaptcha.yml
+++ b/data/rules/recaptcha.yml
@@ -9,7 +9,7 @@ rules:
       (
         6l[c-f][a-z0-9_-].{36}
       )
-      \b
+      (?:[^A-Za-z0-9/]|$)
     pattern_requirements:
       min_digits: 3
     min_entropy: 3

--- a/data/rules/sentry.yml
+++ b/data/rules/sentry.yml
@@ -50,7 +50,7 @@ rules:
     confidence: medium
     examples:
       - sntrys_eyJpYXQiOjE2OTA4ODAwMDAsInJlZ2lvbl91cmwiOiJodHRwczovL3NlbnRyeS5pby9vcmdzL215LW9yZy8ifQ==_abcdefghijklmnopqrstuvwx1234567890abcdefabc
-      - sntrys_eyJpYXQiOiIxNjkwODgwMDAwIiwicmVnaW9uX3VybCI6Imh0dHBzOi8vc2VudHJ5LmlvLyJ9_abcdABCD1234567890abcdABCD1234567890abcdABCD
+      - sntrys_eyJpYXQiOiIxNjkwODgwMDAwIiwicmVnaW9uX3VybCI6Imh0dHBzOi8vc2VudHJ5LmlvLyJ9_abcdABCD1234567890abcdABCD1234567890abcdABC
     references:
       - https://docs.sentry.io/api/auth/
     validation:

--- a/data/rules/square.yml
+++ b/data/rules/square.yml
@@ -16,7 +16,7 @@ rules:
     min_entropy: 3.3
     confidence: medium
     examples:
-      - square EAAA7h9fL9zQJR8P0eAioAf9239345rDA2349bQ8edUA9FgA5JojdsF3A9f6nKLmn
+      - square EAAA7h9fL9zQJR8P0eAioAf9239345rDA2349bQ8edUA9FgA5JojdsF3A9f6nKLm
       - square EAAAvlYh9H7dZwC9ash2hrHjtlL5D2srERGK5OM6F2nvle23he3NzA60PAeFXNHj
     validation:
       type: Http

--- a/data/rules/twitch.yml
+++ b/data/rules/twitch.yml
@@ -3,7 +3,6 @@ rules:
     id: kingfisher.twitch.1
     pattern: |
       (?xi)
-      \b
       twitch
       (?:.|[\n\r]){0,32}?
       \b
@@ -19,7 +18,7 @@ rules:
     confidence: medium
     examples:
       - TWITCH_TOKEN=abcdefghijklmnopqrstuvwx123456
-      - "twitch_api_token: '0123456789abcdefghijklmnopqrstuv'"
+      - "twitch_api_token: '0123456789abcdefghijklmnopqrst'"
     references:
       - https://dev.twitch.tv/docs/authentication/validate-tokens/
     validation:

--- a/src/cli/commands/scan.rs
+++ b/src/cli/commands/scan.rs
@@ -144,6 +144,10 @@ pub struct ScanArgs {
     /// Disable inline ignore directives entirely
     #[arg(long = "no-ignore", default_value_t = false)]
     pub no_inline_ignore: bool,
+
+    /// Disable rule-level `ignore_if_contains` filtering for pattern requirements
+    #[arg(long = "no-ignore-if-contains", default_value_t = false)]
+    pub no_ignore_if_contains: bool,
 }
 
 /// Confidence levels for findings

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,6 +446,7 @@ fn create_default_scan_args() -> cli::commands::scan::ScanArgs {
         output_args: OutputArgs { output: None, format: ReportOutputFormat::Pretty },
         no_base64: false,
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     }
 }
 /// Run the rules check command

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -807,6 +807,7 @@ mod tests {
             skip_aws_account: Vec::new(),
             skip_aws_account_file: None,
             no_inline_ignore: false,
+            no_ignore_if_contains: false,
         }
     }
 

--- a/src/reporter/json_format.rs
+++ b/src/reporter/json_format.rs
@@ -180,6 +180,7 @@ mod tests {
             skip_aws_account_file: None,
             no_base64: false,
             no_inline_ignore: false,
+            no_ignore_if_contains: false,
         }
     }
 

--- a/src/scanner/enumerate.rs
+++ b/src/scanner/enumerate.rs
@@ -169,6 +169,7 @@ pub fn enumerate_filesystem_inputs(
         Some(shared_profiler),
         &args.extra_ignore_comments,
         args.no_inline_ignore,
+        !args.no_ignore_if_contains,
     )?;
     let blob_processor_init_time = Mutex::new(t1.elapsed());
     let make_blob_processor = || -> BlobProcessor {

--- a/src/scanner/repos.rs
+++ b/src/scanner/repos.rs
@@ -683,6 +683,7 @@ pub async fn fetch_s3_objects(
         Some(shared_profiler.clone()),
         &args.extra_ignore_comments,
         args.no_inline_ignore,
+        !args.no_ignore_if_contains,
     )?;
     let mut processor = BlobProcessor { matcher };
 
@@ -764,6 +765,7 @@ pub async fn fetch_gcs_objects(
         Some(shared_profiler.clone()),
         &args.extra_ignore_comments,
         args.no_inline_ignore,
+        !args.no_ignore_if_contains,
     )?;
     let mut processor = BlobProcessor { matcher };
 

--- a/tests/int_allowlist.rs
+++ b/tests/int_allowlist.rs
@@ -148,6 +148,7 @@ fn run_skiplist(skip_regex: Vec<String>, skip_skipword: Vec<String>) -> Result<u
         skip_aws_account_file: None,
         no_base64: false,
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {

--- a/tests/int_bitbucket.rs
+++ b/tests/int_bitbucket.rs
@@ -148,6 +148,7 @@ fn test_bitbucket_remote_scan() -> Result<()> {
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {

--- a/tests/int_dedup.rs
+++ b/tests/int_dedup.rs
@@ -168,6 +168,7 @@ rules:
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {

--- a/tests/int_github.rs
+++ b/tests/int_github.rs
@@ -155,6 +155,7 @@ fn test_github_remote_scan() -> Result<()> {
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
     // Create global arguments
     let global_args = GlobalArgs {

--- a/tests/int_gitlab.rs
+++ b/tests/int_gitlab.rs
@@ -153,6 +153,7 @@ fn test_gitlab_remote_scan() -> Result<()> {
         skip_aws_account_file: None,
         no_base64: false,
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {
@@ -304,6 +305,7 @@ fn test_gitlab_remote_scan_no_history() -> Result<()> {
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {

--- a/tests/int_redact.rs
+++ b/tests/int_redact.rs
@@ -131,6 +131,7 @@ async fn test_redact_hashes_finding_values() -> Result<()> {
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {

--- a/tests/int_slack.rs
+++ b/tests/int_slack.rs
@@ -139,6 +139,7 @@ impl TestContext {
             skip_aws_account_file: None,
             no_base64: false,
             no_inline_ignore: false,
+            no_ignore_if_contains: false,
         };
 
         let loaded = RuleLoader::from_rule_specifiers(&scan_args.rules).load(&scan_args)?;
@@ -278,6 +279,7 @@ async fn test_scan_slack_messages() -> Result<()> {
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     let global_args = GlobalArgs {

--- a/tests/int_validation_cache.rs
+++ b/tests/int_validation_cache.rs
@@ -211,6 +211,7 @@ async fn test_validation_cache_and_depvars() -> Result<()> {
         no_base64: false,
         extra_ignore_comments: Vec::new(),
         no_inline_ignore: false,
+        no_ignore_if_contains: false,
     };
 
     /* --------------------------------------------------------- *

--- a/tests/int_vulnerable_files.rs
+++ b/tests/int_vulnerable_files.rs
@@ -154,6 +154,7 @@ impl TestContext {
             no_base64: false,
             extra_ignore_comments: Vec::new(),
             no_inline_ignore: false,
+            no_ignore_if_contains: false,
         };
 
         let loaded = RuleLoader::from_rule_specifiers(&scan_args.rules)
@@ -281,6 +282,7 @@ impl TestContext {
             skip_aws_account_file: None,
             no_base64: false,
             no_inline_ignore: false,
+            no_ignore_if_contains: false,
         };
 
         let global_args = GlobalArgs {

--- a/tests/smoke_baseline.rs
+++ b/tests/smoke_baseline.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
 use assert_cmd::Command;
+use clap::Parser;
 use predicates::prelude::*;
 use tempfile::tempdir;
-use clap::Parser;
 
 const GH_PAT: &str = "ghp_1wuHFikBKQtCcH3EB2FBUkyn8krXhP2qLqPa";
 


### PR DESCRIPTION
…s containing case-insensitive placeholder words are filtered out, with accompanying tests to cover the new behavior.